### PR TITLE
feat: improve gas usage of ChunkedVestingVault

### DIFF
--- a/.gas-comparison
+++ b/.gas-comparison
@@ -1,0 +1,28 @@
+
+# Tests run with storage instead of immutable args
+Running 11 tests for src/test/ChunkedVestingVaultStorage.t.sol:ChunkedVestingVaultStorageTest
+[PASS] testClaimPartial() (gas: 183208)
+[PASS] testDifferingAmounts() (gas: 545082)
+[PASS] testFailClaimUnauthorized(uint256) (runs: 256, μ: 92094, ~: 92094)
+[PASS] testFailClaimZero() (gas: 41685)
+[PASS] testFailTooManyAmounts() (gas: 15334)
+[PASS] testFailTooManyTimestamps() (gas: 15435)
+[PASS] testInstantiation() (gas: 62557)
+[PASS] testManyUnlocks() (gas: 34034260)
+[PASS] testSingleUnlock(uint256) (runs: 256, μ: 402109, ~: 402097)
+[PASS] testVestAllThenClaim() (gas: 146317)
+[PASS] testWarpAndClaim(uint256) (runs: 256, μ: 94849, ~: 113309)
+Test result: ok. 11 passed; 0 failed; finished in 319.46ms
+
+# Tests run with immutable args
+[PASS] testClaimPartial() (gas: 175621)
+[PASS] testDifferingAmounts() (gas: 375304)
+[PASS] testFailClaimUnauthorized(uint256) (runs: 256, μ: 90222, ~: 90222)
+[PASS] testFailClaimZero() (gas: 34582)
+[PASS] testFailTooManyAmounts() (gas: 14494)
+[PASS] testFailTooManyTimestamps() (gas: 14598)
+[PASS] testInstantiation() (gas: 45895)
+[PASS] testManyUnlocks() (gas: 27770461)
+[PASS] testSingleUnlock(uint256) (runs: 256, μ: 303555, ~: 303566)
+[PASS] testVestAllThenClaim() (gas: 136406)
+[PASS] testWarpAndClaim(uint256) (runs: 256, μ: 83427, ~: 95396)

--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,0 +1,8 @@
+ChunkedVestingVaultTest:testClaimPartial() (gas: 175621)
+ChunkedVestingVaultTest:testDifferingAmounts() (gas: 375304)
+ChunkedVestingVaultTest:testFailClaimZero() (gas: 34582)
+ChunkedVestingVaultTest:testFailTooManyAmounts() (gas: 14494)
+ChunkedVestingVaultTest:testFailTooManyTimestamps() (gas: 14598)
+ChunkedVestingVaultTest:testInstantiation() (gas: 45895)
+ChunkedVestingVaultTest:testManyUnlocks() (gas: 27770461)
+ChunkedVestingVaultTest:testVestAllThenClaim() (gas: 136406)

--- a/src/ChunkedVestingVaultFactory.sol
+++ b/src/ChunkedVestingVaultFactory.sol
@@ -7,7 +7,7 @@ import {SafeERC20Upgradeable} from "openzeppelin-contracts-upgradeable/contracts
 import {ChunkedVestingVault} from "./ChunkedVestingVault.sol";
 import {IVestingVaultFactory} from "./interfaces/IVestingVaultFactory.sol";
 
-contract ChunkedVestingVaultFactory is IVestingVaultFactory{
+contract ChunkedVestingVaultFactory is IVestingVaultFactory {
     using SafeERC20Upgradeable for IERC20Upgradeable;
     using ClonesWithImmutableArgs for address;
 
@@ -21,6 +21,10 @@ contract ChunkedVestingVaultFactory is IVestingVaultFactory{
      * @notice Creates a new vesting vault
      * @param token The ERC20 token to vest over time
      * @param beneficiary The address who will receive tokens over time
+     * @param amounts The amounts to be vested per chunk.
+     *  This is assumed to be sorted in unlock order
+     * @param timestamps The amounts to be vested per chunk.
+     *  This is assumed to be sorted in ascending time order
      */
     function createVault(
         address token,

--- a/src/helpers/ChunkedVestingVaultArgs.sol
+++ b/src/helpers/ChunkedVestingVaultArgs.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import {Clone} from "clones-with-immutable-args/Clone.sol";
+
+/**
+ * @notice helpers for the immutable args
+ * stored by ChunkedVestingVault
+ */
+contract ChunkedVestingVaultArgs is Clone {
+    /**
+     * @notice The token which is being vested
+     * @dev using ClonesWithImmutableArgs pattern here to save gas
+     * @dev https://github.com/wighawag/clones-with-immutable-args
+     * @return the token which is being vested
+     */
+    function vestingPeriods() public pure returns (uint256) {
+        // starts at 40 because of the parent VestingVault uses bytes 0-39 for token and beneficiary
+        return _getArgUint256(40);
+    }
+
+    /**
+     * @notice The array of chunked amounts to be vested
+     * @dev using ClonesWithImmutableArgs pattern here to save gas
+     * @dev https://github.com/wighawag/clones-with-immutable-args
+     * @return the array of chunked amounts to be vested
+     */
+    function amounts() public pure returns (uint256[] memory) {
+        return _getArgUint256Array(72, uint64(vestingPeriods()));
+    }
+
+    /**
+     * @notice The array of timestamps at which chunks of tokens are vested
+     * @dev using ClonesWithImmutableArgs pattern here to save gas
+     * @dev https://github.com/wighawag/clones-with-immutable-args
+     * @dev These are expected to be already sorted in timestamp order
+     * @return the timestamps at which chunks of tokens are vested
+     */
+    function timestamps() public pure returns (uint256[] memory) {
+        return
+            _getArgUint256Array(
+                72 + (32 * vestingPeriods()),
+                uint64(vestingPeriods())
+            );
+    }
+
+    /**
+     * @notice The amount to be vested at the given index
+     * @dev using ClonesWithImmutableArgs pattern here to save gas
+     * @dev https://github.com/wighawag/clones-with-immutable-args
+     * @return the amount to be vested at the given index
+     */
+    function amountAtIndex(uint256 index) public pure returns (uint256) {
+        return _getArgUint256(72 + (32 * index));
+    }
+
+    /**
+     * @notice The timestamp at which the given index chunk is vested
+     * @dev using ClonesWithImmutableArgs pattern here to save gas
+     * @dev https://github.com/wighawag/clones-with-immutable-args
+     * @return the timestamp at which the given index chunk is vested
+     */
+    function timestampAtIndex(uint256 index) public pure returns (uint256) {
+        return _getArgUint256(72 + (32 * vestingPeriods()) + (32 * index));
+    }
+}

--- a/src/interfaces/IVestingVaultFactory.sol
+++ b/src/interfaces/IVestingVaultFactory.sol
@@ -9,9 +9,8 @@ pragma solidity 0.8.10;
  * functions
  */
 interface IVestingVaultFactory {
-    event VaultCreated(token, beneficiary);
+    event VaultCreated(address token, address beneficiary);
 
     /// @notice Some parameters are invalid
     error InvalidParams();
-
 }


### PR DESCRIPTION
This commit improves gas usage significantly for ChunkedVestingVault.
By changing the chunk processing logic to fetch slot-by-slot from the
array rather than loading the entire array into memory all at once, we
save around 30% gas on most test cases, and over 10x on the large
TestManyUnlocks test (runs through a 500-chunk vest period). Also ran
a comparison against a storage-based contract rather than
clones-with-immutable-args pattern, and saw a nice comparison - saved in
.gas-comparison file.